### PR TITLE
fix: auto-detect non-interactive CI to prevent validation timeout

### DIFF
--- a/docs/src/3-deployment/deploy.md
+++ b/docs/src/3-deployment/deploy.md
@@ -11,7 +11,7 @@ Complete guide for deploying foundry-azure-local-chat to Azure using `azd`.
 The fastest way to deploy — a recipe sets all defaults for you:
 
 ```bash
-azd env set RECIPE all    # full stack + MS Foundry (gpt-4o-mini, D2s_v5, 2 nodes)
+azd env set RECIPE all    # full stack + MS Foundry (gpt-4o-mini, D2s_v6, 2 nodes)
 azd up                    # prompts for subscription + location, recipe handles the rest
 ```
 
@@ -19,7 +19,7 @@ Available recipes:
 
 | Recipe | What you get                                                   |
 | ------ | -------------------------------------------------------------- |
-| `all`  | Full stack + MS Foundry (gpt-4o-mini, D2s_v5, 2 nodes)         |
+| `all`  | Full stack + MS Foundry (gpt-4o-mini, D2s_v6, 2 nodes)         |
 | `dev`  | Full stack + mock AI (B2s cheapest VM, admin enabled, CORS=\*) |
 
 > **Note:** `ARC_PREFIX` is auto-derived from the azd environment name. `azd env new my-chat` creates `my-chat-rg`, `my-chat-cluster`, etc.
@@ -165,7 +165,7 @@ Complete reference for all `azd` environment variables. Most are set automatical
 | `RECIPE` | - | - | `all` (full stack + MS Foundry), `dev` (mock + cheapest VM), or empty for wizard |
 | `ARC_PREFIX` | auto | - | Auto-derived from azd env name — do NOT set manually |
 | `NODE_COUNT` | ✅ | - | AKS node count |
-| `VM_SIZE` | ✅ | - | AKS VM size (e.g. `Standard_D2s_v5`) |
+| `VM_SIZE` | ✅ | - | AKS VM size (e.g. `Standard_D2s_v6`) |
 | `DEPLOY_MODE` | ✅ | - | `k8s` or `containerapp` |
 | `DEPLOY_SCOPE` | - | `all` | `all`, `frontend`, or `backend` |
 | `AZURE_LOCATION` | auto | - | Set during `azd init` |

--- a/hooks/deploy.sh
+++ b/hooks/deploy.sh
@@ -17,6 +17,10 @@ AUTO_YES=false
 for arg in "$@"; do
     [[ "$arg" == "-y" || "$arg" == "--yes" ]] && AUTO_YES=true
 done
+# Auto-detect CI / non-interactive: if stdin is not a terminal, skip prompts
+if [ ! -t 0 ]; then
+    AUTO_YES=true
+fi
 # Check if preprovision set auto-deploy flag (temp file, survives azd provision)
 if [ "$AUTO_YES" != "true" ]; then
     _env_name=""

--- a/hooks/preprovision.ps1
+++ b/hooks/preprovision.ps1
@@ -199,13 +199,13 @@ function Wizard-Infrastructure {
     Prompt-Val "NODE_COUNT" "AKS node count" "2" "" "Number of nodes in the AKS cluster (2 for dev, 3+ for prod)"
 
     # ── VM size selector — popular first, with expand + custom ────
-    $POP_VM_V = @("Standard_B2s", "Standard_D2s_v5", "Standard_D4s_v5", "Standard_D2s_v3", "Standard_D4s_v3", "Standard_B4ms")
+    $POP_VM_V = @("Standard_B2s", "Standard_D2s_v6", "Standard_D4s_v6", "Standard_D2s_v5", "Standard_D4s_v5", "Standard_B4ms")
     $POP_VM_D = @(
         "Standard_B2s ${DIM}`u{2014} 2 vCPU, 4 GB (burstable, cheapest)${NC}"
-        "Standard_D2s_v5 ${DIM}`u{2014} 2 vCPU, 8 GB${NC} ${GREEN}(Recommended)${NC}"
-        "Standard_D4s_v5 ${DIM}`u{2014} 4 vCPU, 16 GB (prod)${NC}"
-        "Standard_D2s_v3 ${DIM}`u{2014} 2 vCPU, 8 GB (prev gen)${NC}"
-        "Standard_D4s_v3 ${DIM}`u{2014} 4 vCPU, 16 GB (prev gen)${NC}"
+        "Standard_D2s_v6 ${DIM}`u{2014} 2 vCPU, 8 GB${NC} ${GREEN}(Recommended)${NC}"
+        "Standard_D4s_v6 ${DIM}`u{2014} 4 vCPU, 16 GB (prod)${NC}"
+        "Standard_D2s_v5 ${DIM}`u{2014} 2 vCPU, 8 GB (prev gen)${NC}"
+        "Standard_D4s_v5 ${DIM}`u{2014} 4 vCPU, 16 GB (prev gen)${NC}"
         "Standard_B4ms ${DIM}`u{2014} 4 vCPU, 16 GB (burstable)${NC}"
     )
     $POP_VM_V += "__more__"; $POP_VM_V += "__custom__"
@@ -214,7 +214,7 @@ function Wizard-Infrastructure {
 
     Write-Host "  ${DIM}VM size for AKS nodes.${NC}"
     while ($true) {
-        Prompt-Select "VM_SIZE" "AKS VM size" $POP_VM_V $POP_VM_D "" "Standard_D2s_v5"
+        Prompt-Select "VM_SIZE" "AKS VM size" $POP_VM_V $POP_VM_D "" "Standard_D2s_v6"
         $VM_PICKED = Get-Val "VM_SIZE"
 
         if ($VM_PICKED -eq "__back__") {
@@ -233,8 +233,8 @@ function Wizard-Infrastructure {
                 "Standard_B4ms ${DIM}`u{2014} 4 vCPU, 16 GB (burstable)${NC}"
                 "Standard_D2s_v3 ${DIM}`u{2014} 2 vCPU, 8 GB (prev gen)${NC}"
                 "Standard_D2ds_v5 ${DIM}`u{2014} 2 vCPU, 8 GB (local SSD)${NC}"
-                "Standard_D2s_v5 ${DIM}`u{2014} 2 vCPU, 8 GB${NC} ${GREEN}(Recommended)${NC}"
-                "Standard_D2s_v6 ${DIM}`u{2014} 2 vCPU, 8 GB (newest)${NC}"
+                "Standard_D2s_v5 ${DIM}`u{2014} 2 vCPU, 8 GB${NC}"
+                "Standard_D2s_v6 ${DIM}`u{2014} 2 vCPU, 8 GB (newest)${NC} ${GREEN}(Recommended)${NC}"
                 "Standard_D2as_v5 ${DIM}`u{2014} 2 vCPU, 8 GB (AMD)${NC}"
                 "Standard_D4s_v3 ${DIM}`u{2014} 4 vCPU, 16 GB${NC}"
                 "Standard_D4s_v5 ${DIM}`u{2014} 4 vCPU, 16 GB${NC}"
@@ -249,13 +249,13 @@ function Wizard-Infrastructure {
                 "Standard_F4s_v2 ${DIM}`u{2014} 4 vCPU, 8 GB (compute opt)${NC}"
                 "Standard_F8s_v2 ${DIM}`u{2014} 8 vCPU, 16 GB (compute opt)${NC}"
             )
-            Prompt-Select "VM_SIZE" "AKS VM size" $EXT_V $EXT_D "" "Standard_D2s_v5"
+            Prompt-Select "VM_SIZE" "AKS VM size" $EXT_V $EXT_D "" "Standard_D2s_v6"
             if ((Get-Val "VM_SIZE") -eq "__back__") { Save-Val "VM_SIZE" ""; continue }
             break
         } elseif ($VM_PICKED -eq "__custom__") {
             Save-Val "VM_SIZE" ""
-            Prompt-Val "VM_SIZE" "VM size name" "Standard_D2s_v5" "--required" `
-                "Enter the exact Azure VM size (e.g. Standard_D2s_v5, Standard_E4s_v5)"
+            Prompt-Val "VM_SIZE" "VM size name" "Standard_D2s_v6" "--required" `
+                "Enter the exact Azure VM size (e.g. Standard_D2s_v6, Standard_E4s_v5)"
             break
         } else {
             break
@@ -680,7 +680,7 @@ function Apply-Recipe {
             Save-Val "STREAMING" "enabled"
             Save-Val "CORS_ORIGINS" "auto"
             Save-Val "ENABLE_ADMIN_ROUTES" "false"
-            Save-Val "VM_SIZE" "Standard_D2s_v5"
+            Save-Val "VM_SIZE" "Standard_D2s_v6"
             Save-Val "NODE_COUNT" "2"
         }
         "dev" {

--- a/hooks/preprovision.sh
+++ b/hooks/preprovision.sh
@@ -37,6 +37,10 @@ AUTO_YES="${AUTO_YES:-false}"
 for arg in "$@"; do
     [[ "$arg" == "-y" || "$arg" == "--yes" ]] && AUTO_YES=true
 done
+# Auto-detect CI / non-interactive: if stdin is not a terminal, skip prompts
+if [ ! -t 0 ]; then
+    AUTO_YES=true
+fi
 export AUTO_YES
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/hooks/preprovision.sh
+++ b/hooks/preprovision.sh
@@ -210,13 +210,13 @@ wizard_infrastructure() {
         "Number of nodes in the AKS cluster (2 for dev, 3+ for prod)"
 
     # ── VM size selector — popular first, with expand + custom ────
-    local POP_VM_V=("Standard_B2s" "Standard_D2s_v5" "Standard_D4s_v5" "Standard_D2s_v3" "Standard_D4s_v3" "Standard_B4ms")
+    local POP_VM_V=("Standard_B2s" "Standard_D2s_v6" "Standard_D4s_v6" "Standard_D2s_v5" "Standard_D4s_v5" "Standard_B4ms")
     local POP_VM_D=(
         "Standard_B2s ${DIM}— 2 vCPU, 4 GB (burstable, cheapest)${NC}"
-        "Standard_D2s_v5 ${DIM}— 2 vCPU, 8 GB${NC} ${GREEN}(Recommended)${NC}"
-        "Standard_D4s_v5 ${DIM}— 4 vCPU, 16 GB (prod)${NC}"
-        "Standard_D2s_v3 ${DIM}— 2 vCPU, 8 GB (prev gen)${NC}"
-        "Standard_D4s_v3 ${DIM}— 4 vCPU, 16 GB (prev gen)${NC}"
+        "Standard_D2s_v6 ${DIM}— 2 vCPU, 8 GB${NC} ${GREEN}(Recommended)${NC}"
+        "Standard_D4s_v6 ${DIM}— 4 vCPU, 16 GB (prod)${NC}"
+        "Standard_D2s_v5 ${DIM}— 2 vCPU, 8 GB (prev gen)${NC}"
+        "Standard_D4s_v5 ${DIM}— 4 vCPU, 16 GB (prev gen)${NC}"
         "Standard_B4ms ${DIM}— 4 vCPU, 16 GB (burstable)${NC}"
     )
     POP_VM_V+=("__more__" "__custom__")
@@ -225,7 +225,7 @@ wizard_infrastructure() {
     echo -e "  ${DIM}VM size for AKS nodes.${NC}"
     while true; do
         prompt_select "VM_SIZE" "AKS VM size" POP_VM_V POP_VM_D \
-            "" "Standard_D2s_v5"
+            "" "Standard_D2s_v6"
         local VM_PICKED; VM_PICKED=$(get_val "VM_SIZE")
 
         if [ "$VM_PICKED" = "__back__" ]; then
@@ -244,8 +244,8 @@ wizard_infrastructure() {
                 "Standard_B4ms ${DIM}— 4 vCPU, 16 GB (burstable)${NC}"
                 "Standard_D2s_v3 ${DIM}— 2 vCPU, 8 GB (prev gen)${NC}"
                 "Standard_D2ds_v5 ${DIM}— 2 vCPU, 8 GB (local SSD)${NC}"
-                "Standard_D2s_v5 ${DIM}— 2 vCPU, 8 GB${NC} ${GREEN}(Recommended)${NC}"
-                "Standard_D2s_v6 ${DIM}— 2 vCPU, 8 GB (newest)${NC}"
+                "Standard_D2s_v5 ${DIM}— 2 vCPU, 8 GB${NC}"
+                "Standard_D2s_v6 ${DIM}— 2 vCPU, 8 GB (newest)${NC} ${GREEN}(Recommended)${NC}"
                 "Standard_D2as_v5 ${DIM}— 2 vCPU, 8 GB (AMD)${NC}"
                 "Standard_D4s_v3 ${DIM}— 4 vCPU, 16 GB${NC}"
                 "Standard_D4s_v5 ${DIM}— 4 vCPU, 16 GB${NC}"
@@ -259,13 +259,13 @@ wizard_infrastructure() {
                 "Standard_F2s_v2 ${DIM}— 2 vCPU, 4 GB (compute opt)${NC}"
                 "Standard_F4s_v2 ${DIM}— 4 vCPU, 8 GB (compute opt)${NC}"
                 "Standard_F8s_v2 ${DIM}— 8 vCPU, 16 GB (compute opt)${NC}")
-            prompt_select "VM_SIZE" "AKS VM size" EXT_V EXT_D "" "Standard_D2s_v5"
+            prompt_select "VM_SIZE" "AKS VM size" EXT_V EXT_D "" "Standard_D2s_v6"
             [ "$(get_val "VM_SIZE")" = "__back__" ] && { save_val "VM_SIZE" ""; continue; }
             break
         elif [ "$VM_PICKED" = "__custom__" ]; then
             save_val "VM_SIZE" ""
-            prompt_val "VM_SIZE" "VM size name" "Standard_D2s_v5" --required \
-                "Enter the exact Azure VM size (e.g. Standard_D2s_v5, Standard_E4s_v5)"
+            prompt_val "VM_SIZE" "VM size name" "Standard_D2s_v6" --required \
+                "Enter the exact Azure VM size (e.g. Standard_D2s_v6, Standard_E4s_v5)"
             break
         else
             break
@@ -666,7 +666,7 @@ apply_recipe() {
             save_cached "STREAMING" "enabled"
             save_cached "CORS_ORIGINS" "auto"
             save_cached "ENABLE_ADMIN_ROUTES" "false"
-            save_cached "VM_SIZE" "Standard_D2s_v5"
+            save_cached "VM_SIZE" "Standard_D2s_v6"
             save_cached "NODE_COUNT" "2"
             ;;
         dev)

--- a/infra/README.md
+++ b/infra/README.md
@@ -15,7 +15,7 @@ azd init
 
 azd env set ARC_PREFIX "your-prefix"
 azd env set NODE_COUNT "2"
-azd env set VM_SIZE "Standard_D4s_v5"
+azd env set VM_SIZE "Standard_D4s_v6"
 azd env set DEPLOY_MODE "containerapp"    # or "k8s"
 
 azd up
@@ -28,7 +28,7 @@ azd init
 
 azd env set ARC_PREFIX "your-prefix"
 azd env set NODE_COUNT "2"
-azd env set VM_SIZE "Standard_D2s_v5"
+azd env set VM_SIZE "Standard_D2s_v6"
 azd env set DEPLOY_MODE "k8s"
 azd env set DATASOURCES "api"
 azd env set AI_PROJECT_ENDPOINT "https://<name>.cognitiveservices.azure.com/api/projects/<project>"
@@ -45,7 +45,7 @@ azd up
 | TLS | Self-signed (custom domain for real cert) | Free `*.k4apps.io` + auto TLS |
 | API URL | Auto-detected from ingress IP | Auto-detected from backend FQDN |
 | Regions | Any AKS region | 11 regions only |
-| Min VM | D2s_v5 | D4s_v5 |
+| Min VM | D2s_v6 | D4s_v6 |
 | Pods | ~32 | ~62 |
 | Offline | Yes | No |
 | Extra config | — | `CUSTOM_LOCATION_OID` required |
@@ -56,7 +56,7 @@ azd up
 |----------|----------|-------------|
 | `ARC_PREFIX` | ✅ | Resource name prefix — all names derived from this |
 | `NODE_COUNT` | ✅ | AKS node count (e.g. `2`) |
-| `VM_SIZE` | ✅ | AKS VM size (e.g. `Standard_D2s_v5`) |
+| `VM_SIZE` | ✅ | AKS VM size (e.g. `Standard_D2s_v6`) |
 | `DEPLOY_MODE` | ✅ | `k8s` or `containerapp` |
 | `DEPLOY_SCOPE` | optional | `all` (default), `frontend`, or `backend` |
 | `AZURE_LOCATION` | auto | Set during `azd init` (region dropdown) |

--- a/infra/defaults.ps1
+++ b/infra/defaults.ps1
@@ -201,7 +201,7 @@ function Apply-Defaults {
     _Def-Default "AI_MODEL_NAME" "gpt-4o-mini"
     _Def-Default "AI_MODEL_VERSION" "2024-07-18"
     _Def-Default "AI_MODEL_CAPACITY" "1"
-    _Def-Default "VM_SIZE" "Standard_D2s_v5"
+    _Def-Default "VM_SIZE" "Standard_D2s_v6"
     _Def-Default "NODE_COUNT" "2"
     _Def-Default "AZURE_LOCATION" "eastus2"
     _Def-Default "BACKEND_REPLICAS" "1"

--- a/infra/defaults.sh
+++ b/infra/defaults.sh
@@ -169,7 +169,7 @@ apply_defaults() {
     _def_default "AI_MODEL_NAME" "gpt-4o-mini"
     _def_default "AI_MODEL_VERSION" "2024-07-18"
     _def_default "AI_MODEL_CAPACITY" "1"
-    _def_default "VM_SIZE" "Standard_D2s_v5"
+    _def_default "VM_SIZE" "Standard_D2s_v6"
     _def_default "NODE_COUNT" "2"
     _def_default "AZURE_LOCATION" "eastus2"
     _def_default "BACKEND_REPLICAS" "1"

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -28,8 +28,8 @@ param location string
 @description('AKS node count (recommended: 2 for dev, 3+ for prod)')
 param nodeCount int = 2
 
-@description('AKS VM size (recommended: Standard_D2s_v5 for dev, D4s_v5 for prod)')
-param vmSize string = 'Standard_D2s_v5'
+@description('AKS VM size (recommended: Standard_D2s_v6 for dev, D4s_v6 for prod)')
+param vmSize string = 'Standard_D2s_v6'
 
 @description('MS Foundry endpoint (optional — leave empty for mock mode). Also injected into the pod at deploy time.')
 param aiProjectEndpoint string = ''

--- a/infra/naming.ps1
+++ b/infra/naming.ps1
@@ -120,7 +120,7 @@ function Print-ConfigSummary {
         $RG = if ($env:AZURE_RESOURCE_GROUP) { $env:AZURE_RESOURCE_GROUP } else { $script:RES_RESOURCE_GROUP }
         $NS = if ($env:AZURE_NAMESPACE) { $env:AZURE_NAMESPACE } else { $script:RES_NAMESPACE }
         $NC_VAL = if ($env:NODE_COUNT) { $env:NODE_COUNT } else { "2" }
-        $VM_VAL = if ($env:VM_SIZE) { $env:VM_SIZE } else { "Standard_D2s_v5" }
+        $VM_VAL = if ($env:VM_SIZE) { $env:VM_SIZE } else { "Standard_D2s_v6" }
 
         _Row "Infra" "${YELLOW}Infra${NC}"
         _Row "  Cluster:      $CLUSTER" "  Cluster:      ${VAL}${CLUSTER}${NC}"

--- a/infra/naming.sh
+++ b/infra/naming.sh
@@ -107,7 +107,7 @@ print_config_summary() {
     row "  RG:           ${RG}" "  RG:           ${VAL}${RG}${NC}"
     row "  Namespace:    ${NS}" "  Namespace:    ${VAL}${NS}${NC}"
     row "  Mode:         ${MODE}" "  Mode:         ${VAL}${MODE}${NC}"
-    row "  Nodes:        ${NODE_COUNT:-2} x ${VM_SIZE:-Standard_D2s_v5}" "  Nodes:        ${VAL}${NODE_COUNT:-2} x ${VM_SIZE:-Standard_D2s_v5}${NC}"
+    row "  Nodes:        ${NODE_COUNT:-2} x ${VM_SIZE:-Standard_D2s_v6}" "  Nodes:        ${VAL}${NODE_COUNT:-2} x ${VM_SIZE:-Standard_D2s_v6}${NC}"
     row "" ""
     fi
     row "Deploy" "${YELLOW}Deploy${NC}"

--- a/scripts/test-deploy-matrix.sh
+++ b/scripts/test-deploy-matrix.sh
@@ -48,7 +48,7 @@ AZURE_WI_CLIENT_ID="00000000-0000-0000-0000-000000000001"
 AZURE_WI_PRINCIPAL_ID="00000000-0000-0000-0000-000000000002"
 DEPLOY_MODE="k8s"
 NODE_COUNT=2
-VM_SIZE="Standard_D2s_v5"
+VM_SIZE="Standard_D2s_v6"
 IMAGE_TAG="latest"
 BACKEND_REPLICAS=1
 FRONTEND_REPLICAS=1
@@ -329,7 +329,7 @@ for recipe in "all" "dev"; do
             set_test_val "STREAMING" "enabled"
             set_test_val "CORS_ORIGINS" "auto"
             set_test_val "ENABLE_ADMIN_ROUTES" "false"
-            set_test_val "VM_SIZE" "Standard_D2s_v5"
+            set_test_val "VM_SIZE" "Standard_D2s_v6"
             set_test_val "NODE_COUNT" "2"
             ;;
         dev)


### PR DESCRIPTION
The preprovision and deploy hooks blocked on interactive read prompts when run by the template validation pipeline (no TTY), causing a 6h timeout. Now both hooks detect non-interactive stdin (! -t 0) and automatically enable AUTO_YES to skip prompts and use defaults.