### PR TITLE
Add client-side Chat Completions provider (no Express required)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,54 @@ VITE_PROXY_TARGET=http://localhost:3001
 # Use server admin endpoints to toggle at runtime:
 #   curl -X POST http://localhost:3001/api/admin/streaming/toggle
 #   curl -X POST http://localhost:3001/api/admin/datasource/toggle
+
+# ============================================
+# API Mode
+# ============================================
+# Selects the chat backend. Defaults to "server" (the Express server in /server).
+#
+#   server       (default) Browser -> our Express server -> Foundry Responses API.
+#                Honors GET /api/settings for streaming on/off and uses the
+#                /api/conversations + /api/responses routes.
+#
+#   completions  Browser -> /v1/chat/completions DIRECTLY. No Express server in
+#                the loop. Use this when connecting to Foundry Local on Azure
+#                Local, OpenAI, Azure OpenAI, self-hosted vLLM/llama.cpp/Ollama,
+#                or any other OpenAI-compatible inference endpoint. Conversation
+#                history is kept client-side (in memory, optionally mirrored to
+#                localStorage).
+#
+# VITE_API_MODE=server
+
+# ============================================
+# Completions Mode (VITE_API_MODE=completions)
+# ============================================
+# Required when mode is "completions":
+#
+# Endpoint base URL. Either the full /v1/chat/completions URL, or a base ending
+# in /v1 (we append chat/completions for you). Trailing slash tolerated.
+#   VITE_API_URL=https://my-foundry-local.example.com/v1
+#
+# The model id to send in the request body's `model` field.
+#   VITE_COMPLETIONS_MODEL=mistralai/ministral-3-8b-instruct
+#
+# Optional:
+#
+# API key. Sent as both `Authorization: Bearer` and `api-key:` headers, so it
+# works against OpenAI and Azure OpenAI without per-vendor branching. Leave
+# blank for unauthenticated endpoints (Foundry Local on-cluster, Ollama, ...).
+# ⚠️ Anything in VITE_COMPLETIONS_API_KEY ends up in the browser bundle.
+# For production, front the endpoint with an auth-injecting reverse proxy
+# instead of shipping a key in the SPA.
+#   VITE_COMPLETIONS_API_KEY=
+#
+# System prompt prepended to every request (constant across the conversation).
+#   VITE_COMPLETIONS_SYSTEM_PROMPT=You are a helpful assistant.
+#
+# Persist conversation history to localStorage so refreshing the page keeps
+# the sidebar populated. Default is "false" (in-memory only).
+#   VITE_COMPLETIONS_PERSIST_HISTORY=false
+#
+# Storage key prefix for localStorage entries. Change to namespace multiple
+# deployments under the same origin.
+#   VITE_COMPLETIONS_STORAGE_PREFIX=sovereign-chat

--- a/src/services/chatApiFactory.ts
+++ b/src/services/chatApiFactory.ts
@@ -3,18 +3,26 @@
 /**
  * Chat Module Factory
  *
- * Provides the correct Chat API based on server settings.
- * - Standard mode: Uses chatApi (REST)
- * - Streaming mode: Uses streamingChatApi (SSE)
+ * Selects the chat backend at boot:
  *
- * Settings are fetched from server via /api/settings endpoint.
- * Uses dynamic imports for code splitting.
+ *   server       (default) → browser → our Express server (/api) → Foundry Responses API
+ *                            Honors the server's /settings.streaming toggle (streaming
+ *                            vs standard REST), as today.
+ *
+ *   completions  → browser → /v1/chat/completions  (no Express server in the loop)
+ *                  Talks directly to any OpenAI-compatible Chat Completions endpoint
+ *                  (Foundry Local, OpenAI, Azure OpenAI, vLLM, Ollama, llama.cpp, ...).
+ *                  Conversation history is kept client-side. See completions/.
+ *
+ * Mode is selected via VITE_API_MODE. Each provider is dynamic-imported so only the
+ * active mode's code is bundled.
  */
 
+import { env } from "@/config/runtime";
 import type { ChatConversationHook } from "@/hooks/internals/_types";
 import type { BaseChatApi } from "@/types/chat.types";
 
-/** Server settings response */
+/** Server settings response (server mode only) */
 export interface ServerSettings {
   streaming: boolean;
 }
@@ -26,13 +34,14 @@ export interface ChatModule {
   settings: ServerSettings;
 }
 
-import { env } from "@/config/runtime";
+export type ApiMode = "server" | "completions";
 
 // Cache settings to avoid refetching
 let cachedSettings: ServerSettings | null = null;
 
 /**
- * Fetch server settings (cached)
+ * Fetch server settings (cached). Server mode only — in completions mode we
+ * never call /api/settings (the Express server isn't required).
  */
 export const fetchServerSettings = async (): Promise<ServerSettings> => {
   if (cachedSettings) {
@@ -54,11 +63,7 @@ export const fetchServerSettings = async (): Promise<ServerSettings> => {
   return { streaming: false };
 };
 
-/**
- * Load the appropriate API and hook based on server settings.
- * Enables code splitting - only the needed modules are loaded.
- */
-export const loadChatModule = async (): Promise<ChatModule> => {
+const loadServerMode = async (): Promise<ChatModule> => {
   const settings = await fetchServerSettings();
 
   if (settings.streaming) {
@@ -74,4 +79,35 @@ export const loadChatModule = async (): Promise<ChatModule> => {
     import("@/hooks/internals/_useStandardChatConversation"),
   ]);
   return { api: chatApi, useChatConversation: useStandardChatConversation, settings };
+};
+
+const loadCompletionsMode = async (): Promise<ChatModule> => {
+  const [{ completionsChatApi }, { useStreamingChatConversation }] = await Promise.all([
+    import("./completions/completionsChatApi"),
+    import("@/hooks/internals/_useStreamingChatConversation"),
+  ]);
+  return {
+    api: completionsChatApi,
+    useChatConversation: useStreamingChatConversation,
+    settings: { streaming: true },
+  };
+};
+
+const MODE_LOADERS: Record<ApiMode, () => Promise<ChatModule>> = {
+  server: loadServerMode,
+  completions: loadCompletionsMode,
+};
+
+/**
+ * Load the appropriate API and hook based on VITE_API_MODE.
+ * Enables code splitting - only the active mode's code is bundled.
+ */
+export const loadChatModule = async (): Promise<ChatModule> => {
+  const mode = (env("VITE_API_MODE", "server") || "server") as ApiMode;
+  const loader = MODE_LOADERS[mode];
+  if (!loader) {
+    console.warn(`[ChatFactory] Unknown VITE_API_MODE="${mode}", falling back to "server".`);
+    return loadServerMode();
+  }
+  return loader();
 };

--- a/src/services/completions/completionsChatApi.ts
+++ b/src/services/completions/completionsChatApi.ts
@@ -1,0 +1,379 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+/**
+ * Completions Chat API
+ *
+ * Client-side adapter that talks DIRECTLY (browser → endpoint) to any
+ * OpenAI-compatible `/v1/chat/completions` endpoint. No Express server needed.
+ * Works with:
+ *   - Foundry Local on Azure Local (vLLM / onnx-genai runtimes)
+ *   - OpenAI / Azure OpenAI
+ *   - Self-hosted vLLM, llama.cpp server, Ollama (OpenAI-compat mode), etc.
+ *
+ * Why this provider exists
+ *   The Chat Completions API is stateless — no server-side conversations or
+ *   threads. This adapter keeps a client-side `CompletionsHistoryStore` so the
+ *   UI's conversation/history contract still works without any backend.
+ *
+ * Auth
+ *   If `VITE_COMPLETIONS_API_KEY` is set, we send it as `Authorization: Bearer <key>`
+ *   AND `api-key: <key>` (Azure-style). Either is harmless to the other server and
+ *   avoids per-vendor branching.
+ *
+ *   ⚠️ Anything in `VITE_COMPLETIONS_API_KEY` ships in the browser bundle. For
+ *   production, prefer fronting the endpoint with an auth-injecting reverse proxy.
+ *
+ * URL handling
+ *   `VITE_API_URL` should be the FULL URL to the chat completions endpoint, OR
+ *   end with `/v1` (we'll append `chat/completions`). Trailing slash is tolerated.
+ */
+
+import { env } from "@/config/runtime";
+import type { Message } from "@/types/api.types";
+import type {
+  ChatConversation,
+  SendMessageOptions,
+  SendMessageResult,
+  StreamCallbacks,
+  StreamingChatApi,
+} from "@/types/chat.types";
+import { createConversation as createConversationObj, generateTitle } from "@/utils/conversation-helpers";
+import { isAbortError } from "@/utils/errors";
+import { generateId } from "@/utils/id";
+
+import type {
+  ChatCompletionMessage,
+  ChatCompletionRequest,
+  ChatCompletionResponse,
+  ChatCompletionsErrorBody,
+  ChatCompletionStreamChunk,
+} from "./completionsChatApi.types";
+import { CompletionsHistoryStore } from "./historyStore";
+
+const toMessageContent = (text: string): Message["content"] => [{ type: "text", text }];
+
+const extractText = (msg: Message): string => {
+  for (const part of msg.content) {
+    if (part.type === "input_text" || part.type === "output_text" || part.type === "text") {
+      const t = (part as { text?: unknown }).text;
+      if (typeof t === "string") {
+        return t;
+      }
+    }
+  }
+  return "";
+};
+
+const toCompletionRole = (role: Message["role"]): ChatCompletionMessage["role"] => {
+  if (role === "user" || role === "assistant" || role === "system") {
+    return role;
+  }
+  // developer/tool/critic/etc. → user (safest default for unknown roles)
+  return "user";
+};
+
+const buildEndpoint = (baseUrl: string): string => {
+  const trimmed = baseUrl.replace(/\/$/, "");
+  if (trimmed.endsWith("/chat/completions")) {
+    return trimmed;
+  }
+  if (trimmed.endsWith("/v1")) {
+    return `${trimmed}/chat/completions`;
+  }
+  return `${trimmed}/v1/chat/completions`;
+};
+
+class CompletionsChatApiService implements StreamingChatApi {
+  private readonly endpoint = buildEndpoint(env("VITE_API_URL", "/v1"));
+  private readonly model = env("VITE_COMPLETIONS_MODEL", "");
+  private readonly apiKey = env("VITE_COMPLETIONS_API_KEY", "");
+  private readonly systemPrompt = env("VITE_COMPLETIONS_SYSTEM_PROMPT", "");
+  private readonly store = new CompletionsHistoryStore(
+    env("VITE_COMPLETIONS_PERSIST_HISTORY", "false") === "true",
+    env("VITE_COMPLETIONS_STORAGE_PREFIX", "sovereign-chat"),
+  );
+  private abortController: AbortController | null = null;
+
+  constructor() {
+    if (this.apiKey) {
+      console.warn(
+        "[completions] ⚠️ Static API key detected in browser bundle (VITE_COMPLETIONS_API_KEY). " +
+          "This value is inlined at build time and visible in source maps and the network tab. " +
+          "INSECURE for production — front the endpoint with an auth-injecting reverse proxy instead.",
+      );
+    }
+    if (!this.model) {
+      console.warn("[completions] VITE_COMPLETIONS_MODEL is not set — requests will fail.");
+    }
+  }
+
+  private buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.apiKey) {
+      headers["Authorization"] = `Bearer ${this.apiKey}`;
+      headers["api-key"] = this.apiKey;
+    }
+    return headers;
+  }
+
+  private buildMessagesPayload(conversationId: string): ChatCompletionMessage[] {
+    const out: ChatCompletionMessage[] = [];
+    if (this.systemPrompt) {
+      out.push({ role: "system", content: this.systemPrompt });
+    }
+    for (const m of this.store.getMessages(conversationId)) {
+      out.push({ role: toCompletionRole(m.role), content: extractText(m) });
+    }
+    return out;
+  }
+
+  private async parseError(res: Response): Promise<string> {
+    try {
+      const body = (await res.json()) as ChatCompletionsErrorBody;
+      return body?.error?.message || `${res.status} ${res.statusText}`;
+    } catch {
+      return `${res.status} ${res.statusText}`;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Conversations
+  // ---------------------------------------------------------------------------
+
+  fetchConversations = async (): Promise<ChatConversation[]> => {
+    return this.store.listConversations();
+  };
+
+  fetchConversation = async (id: string): Promise<ChatConversation | null> => {
+    return this.store.getConversation(id) ?? null;
+  };
+
+  createConversation = async (title?: string): Promise<ChatConversation> => {
+    const conv = createConversationObj(generateId("conv"), title ?? "New Chat");
+    this.store.upsertConversation(conv);
+    return conv;
+  };
+
+  deleteConversation = async (id: string): Promise<void> => {
+    this.store.deleteConversation(id);
+  };
+
+  renameConversation = async (id: string, newTitle: string): Promise<void> => {
+    this.store.renameConversation(id, newTitle);
+  };
+
+  // ---------------------------------------------------------------------------
+  // Messages
+  // ---------------------------------------------------------------------------
+
+  fetchMessages = async (conversationId: string): Promise<{ messages: Message[]; hasMore: boolean; lastId?: string }> => {
+    const messages = this.store.getMessages(conversationId);
+    return { messages, hasMore: false, lastId: messages.length ? messages[messages.length - 1].id : undefined };
+  };
+
+  // ---------------------------------------------------------------------------
+  // Send message (non-streaming)
+  // ---------------------------------------------------------------------------
+
+  sendMessage = async ({ message, conversationId, title }: SendMessageOptions): Promise<SendMessageResult> => {
+    if (this.abortController) {
+      this.abortController.abort();
+    }
+    this.abortController = new AbortController();
+    const signal = this.abortController.signal;
+
+    try {
+      const convId = conversationId || (await this.createConversation(title || generateTitle(message))).id;
+
+      const userMsg: Message = {
+        id: generateId("msg"),
+        type: "message",
+        role: "user",
+        status: "completed",
+        content: toMessageContent(message),
+      };
+      this.store.appendMessage(convId, userMsg);
+
+      const body: ChatCompletionRequest = {
+        model: this.model,
+        messages: this.buildMessagesPayload(convId),
+        stream: false,
+      };
+
+      const res = await fetch(this.endpoint, {
+        method: "POST",
+        headers: this.buildHeaders(),
+        body: JSON.stringify(body),
+        signal,
+      });
+      if (!res.ok) {
+        throw new Error(await this.parseError(res));
+      }
+
+      const data: ChatCompletionResponse = await res.json();
+      const text = data.choices?.[0]?.message?.content || "";
+
+      const assistantMsg: Message = {
+        id: generateId("msg"),
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: toMessageContent(text),
+      };
+      this.store.appendMessage(convId, assistantMsg);
+
+      return { message: assistantMsg, conversationId: convId };
+    } finally {
+      this.abortController = null;
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Send message (streaming)
+  // ---------------------------------------------------------------------------
+
+  sendMessageStreaming = async (
+    { message, conversationId, title }: SendMessageOptions,
+    callbacks: StreamCallbacks,
+  ): Promise<void> => {
+    if (this.abortController) {
+      this.abortController.abort();
+    }
+    this.abortController = new AbortController();
+    const signal = this.abortController.signal;
+
+    try {
+      const convId = conversationId || (await this.createConversation(title || generateTitle(message))).id;
+
+      const userMsg: Message = {
+        id: generateId("msg"),
+        type: "message",
+        role: "user",
+        status: "completed",
+        content: toMessageContent(message),
+      };
+      this.store.appendMessage(convId, userMsg);
+
+      // Tell the UI which conversation this stream belongs to so it can wire up
+      // routes/sidebar before chunks arrive.
+      callbacks.onStart?.({ conversationId: convId });
+
+      const body: ChatCompletionRequest = {
+        model: this.model,
+        messages: this.buildMessagesPayload(convId),
+        stream: true,
+      };
+
+      const res = await fetch(this.endpoint, {
+        method: "POST",
+        headers: this.buildHeaders(),
+        body: JSON.stringify(body),
+        signal,
+      });
+      if (!res.ok) {
+        throw new Error(await this.parseError(res));
+      }
+
+      const fullText = await this.parseSSE(res, callbacks);
+
+      const assistantMsg: Message = {
+        id: generateId("msg"),
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: toMessageContent(fullText),
+      };
+      this.store.appendMessage(convId, assistantMsg);
+    } catch (error) {
+      if (isAbortError(error)) {
+        return;
+      }
+      callbacks.onError?.({ code: "stream_error", message: (error as Error).message });
+    } finally {
+      this.abortController = null;
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // SSE parser — OpenAI Chat Completions streaming format
+  // ---------------------------------------------------------------------------
+  // Each event is a single line: `data: {"choices":[{"delta":{"content":"..."}}]}`
+  // terminated by `data: [DONE]`.
+  private async parseSSE(response: Response, callbacks: StreamCallbacks): Promise<string> {
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error("No response body");
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let fullResponse = "";
+    let completed = false;
+
+    const finish = () => {
+      if (completed) {
+        return;
+      }
+      completed = true;
+      callbacks.onDone?.(fullResponse);
+    };
+
+    try {
+      while (true) {
+        let chunk: ReadableStreamReadResult<Uint8Array>;
+        try {
+          chunk = await reader.read();
+        } catch (error) {
+          if (isAbortError(error)) {
+            // Stream aborted mid-flight — surface partial via onDone so the UI
+            // can finalize the in-progress message bubble.
+            completed = true;
+            callbacks.onDone?.(fullResponse);
+            return fullResponse;
+          }
+          throw error;
+        }
+        if (chunk.done) {
+          break;
+        }
+
+        buffer += decoder.decode(chunk.value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed.startsWith("data:")) {
+            continue;
+          }
+          const data = trimmed.slice(5).trim();
+          if (data === "[DONE]") {
+            finish();
+            return fullResponse;
+          }
+          try {
+            const event: ChatCompletionStreamChunk = JSON.parse(data);
+            const delta = event.choices?.[0]?.delta?.content;
+            if (delta) {
+              fullResponse += delta;
+              callbacks.onChunk?.(delta);
+            }
+          } catch {
+            // Non-JSON / keepalive line — ignore
+          }
+        }
+      }
+      finish();
+      return fullResponse;
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  abort = (): void => {
+    this.abortController?.abort();
+    this.abortController = null;
+  };
+}
+
+export const completionsChatApi = new CompletionsChatApiService();

--- a/src/services/completions/completionsChatApi.types.ts
+++ b/src/services/completions/completionsChatApi.types.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+/**
+ * Types for the OpenAI-compatible Chat Completions API.
+ *
+ * Spec: https://platform.openai.com/docs/api-reference/chat
+ *
+ * Minimal request/response shapes needed to talk to:
+ *   - OpenAI / Azure OpenAI
+ *   - Foundry Local (vLLM / onnx-genai runtimes)
+ *   - Any other OpenAI-compatible inference server
+ */
+
+export type ChatCompletionRole = "system" | "user" | "assistant";
+
+export interface ChatCompletionMessage {
+  role: ChatCompletionRole;
+  content: string;
+}
+
+export interface ChatCompletionRequest {
+  model: string;
+  messages: ChatCompletionMessage[];
+  stream?: boolean;
+  temperature?: number;
+  max_tokens?: number;
+}
+
+export interface ChatCompletionChoice {
+  index: number;
+  message?: ChatCompletionMessage;
+  delta?: { role?: ChatCompletionRole; content?: string };
+  finish_reason?: string | null;
+}
+
+export interface ChatCompletionResponse {
+  id: string;
+  object: "chat.completion";
+  created: number;
+  model: string;
+  choices: ChatCompletionChoice[];
+}
+
+/** A single SSE chunk in streaming mode (`data: {...}`). */
+export interface ChatCompletionStreamChunk {
+  id: string;
+  object: "chat.completion.chunk";
+  created: number;
+  model: string;
+  choices: ChatCompletionChoice[];
+}
+
+export interface ChatCompletionsErrorBody {
+  error?: {
+    message?: string;
+    type?: string;
+    code?: string;
+  };
+}

--- a/src/services/completions/historyStore.ts
+++ b/src/services/completions/historyStore.ts
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+/**
+ * In-memory conversation/message store for the completions provider.
+ *
+ * The OpenAI Chat Completions API is stateless — every request must include the
+ * full conversation context. Since the UI's `sendMessage` signature does NOT pass
+ * prior messages, we keep our own per-conversation store and feed it back into
+ * `messages: [...]` on every request.
+ *
+ * Two modes:
+ *   - persist=false (default): in-memory only. Refreshing the page wipes history.
+ *     Matches a stateless "single conversation" UX.
+ *   - persist=true: mirror writes to localStorage so conversations survive
+ *     reloads. Pair with `VITE_CHAT_ENABLE_HISTORY=true` for a multi-conversation UI.
+ */
+
+import type { ChatConversation, ChatMessage } from "@/types/chat.types";
+
+const CONV_KEY = "conversations";
+const MSG_KEY_PREFIX = "messages.";
+
+interface StoredState {
+  conversations: ChatConversation[];
+}
+
+export class CompletionsHistoryStore {
+  private conversations: ChatConversation[] = [];
+  private messages: Map<string, ChatMessage[]> = new Map();
+
+  constructor(
+    private readonly persist: boolean,
+    private readonly storagePrefix: string,
+  ) {
+    if (this.persist) {
+      this.loadFromStorage();
+    }
+  }
+
+  // -------------------- conversations --------------------
+
+  listConversations(): ChatConversation[] {
+    return [...this.conversations].sort((a, b) => b.created_at - a.created_at);
+  }
+
+  getConversation(id: string): ChatConversation | undefined {
+    return this.conversations.find((c) => c.id === id);
+  }
+
+  upsertConversation(conv: ChatConversation): void {
+    const idx = this.conversations.findIndex((c) => c.id === conv.id);
+    if (idx === -1) {
+      this.conversations.push(conv);
+    } else {
+      this.conversations[idx] = conv;
+    }
+    this.flush();
+  }
+
+  renameConversation(id: string, newTitle: string): void {
+    const conv = this.getConversation(id);
+    if (!conv) {
+      return;
+    }
+    conv.metadata = { ...conv.metadata, title: newTitle };
+    this.flush();
+  }
+
+  deleteConversation(id: string): void {
+    this.conversations = this.conversations.filter((c) => c.id !== id);
+    this.messages.delete(id);
+    if (this.persist) {
+      try {
+        localStorage.removeItem(this.key(MSG_KEY_PREFIX + id));
+      } catch {
+        // ignore quota/availability errors
+      }
+    }
+    this.flush();
+  }
+
+  // -------------------- messages --------------------
+
+  getMessages(conversationId: string): ChatMessage[] {
+    return this.messages.get(conversationId) ?? [];
+  }
+
+  appendMessage(conversationId: string, msg: ChatMessage): void {
+    const list = this.messages.get(conversationId) ?? [];
+    list.push(msg);
+    this.messages.set(conversationId, list);
+    this.flush(conversationId);
+  }
+
+  // -------------------- persistence --------------------
+
+  private key(suffix: string): string {
+    return `${this.storagePrefix}.${suffix}`;
+  }
+
+  private loadFromStorage(): void {
+    try {
+      const raw = localStorage.getItem(this.key(CONV_KEY));
+      if (!raw) {
+        return;
+      }
+      const state: StoredState = JSON.parse(raw);
+      this.conversations = Array.isArray(state.conversations) ? state.conversations : [];
+      for (const conv of this.conversations) {
+        const msgRaw = localStorage.getItem(this.key(MSG_KEY_PREFIX + conv.id));
+        if (msgRaw) {
+          const parsed = JSON.parse(msgRaw);
+          this.messages.set(conv.id, Array.isArray(parsed) ? parsed : []);
+        }
+      }
+    } catch (e) {
+      console.warn("[CompletionsHistoryStore] failed to load from localStorage:", e);
+      this.conversations = [];
+      this.messages.clear();
+    }
+  }
+
+  private flush(conversationId?: string): void {
+    if (!this.persist) {
+      return;
+    }
+    try {
+      localStorage.setItem(this.key(CONV_KEY), JSON.stringify({ conversations: this.conversations }));
+      if (conversationId) {
+        localStorage.setItem(
+          this.key(MSG_KEY_PREFIX + conversationId),
+          JSON.stringify(this.messages.get(conversationId) ?? []),
+        );
+      }
+    } catch (e) {
+      console.warn("[CompletionsHistoryStore] failed to persist:", e);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a third `VITE_API_MODE=completions` that lets the chat experience talk **directly** (browser → endpoint) to any OpenAI-compatible `/v1/chat/completions` endpoint. **No Express server in the loop.**

This is the **client-side architectural variant of #33** (server-side BYOM provider). Both PRs add Chat Completions support to this sample; they take different architectures. See "Relationship to #33" below.

## Architecture

```
server       (default, unchanged)  Browser ──► Express server (/api) ──► Foundry Responses API
completions  (new)                 Browser ──► /v1/chat/completions DIRECTLY  (no server in the loop)
```

`server` mode is the existing behavior — every existing deployment is untouched. The `completions` mode is opt-in via `VITE_API_MODE=completions`.

## When to use which

| Scenario | Best mode |
|---|---|
| Existing Foundry Responses API deployment | `server` |
| Foundry Local on Azure Local (vLLM / onnx-genai) | **`completions`** |
| Self-hosted vLLM / llama.cpp / Ollama | **`completions`** |
| OpenAI / Azure OpenAI direct from a frontend-only app | **`completions`** |
| Need server-side auth injection, rate limiting, or audit logging | `server` (PR #33 BYOM) |

The completions mode is purpose-built for on-prem / edge inference deployments where the model endpoint is already reachable from the browser and the Express translation tier is unnecessary overhead.

## Files changed (+677 / −13)

### New (3 files, all under `src/services/completions/`)
| File | Description |
|---|---|
| `completionsChatApi.ts` | `StreamingChatApi` impl — URL building, headers, SSE parsing, conversation CRUD |
| `completionsChatApi.types.ts` | Minimal OpenAI request/response types |
| `historyStore.ts` | Client-side message store (in-memory + optional `localStorage` mirror) |

### Modified
| File | Change |
|---|---|
| `src/services/chatApiFactory.ts` | Extracts the existing server-mode wiring into `loadServerMode()`, adds `loadCompletionsMode()`, dispatches on `VITE_API_MODE` |
| `.env.example` | New "API Mode" + "Completions Mode" sections with annotated env var docs |

**No new npm dependencies.** No server changes. Bundle impact when mode is `server`: zero (the completions module is dynamic-imported and tree-shaken from the active chunk graph when not selected).

## Configuration

```env
VITE_API_MODE=completions

# Required:
VITE_API_URL=https://your-foundry-local.example.com/v1
VITE_COMPLETIONS_MODEL=mistralai/ministral-3-8b-instruct

# Optional:
VITE_COMPLETIONS_API_KEY=             # sent as Authorization: Bearer + api-key headers
VITE_COMPLETIONS_SYSTEM_PROMPT=       # prepended to every request
VITE_COMPLETIONS_PERSIST_HISTORY=false  # mirror to localStorage
VITE_COMPLETIONS_STORAGE_PREFIX=sovereign-chat
```

⚠️ `VITE_COMPLETIONS_API_KEY` ships in the browser bundle. The provider logs a runtime warning when set. For production, front the endpoint with an auth-injecting reverse proxy instead of inlining a secret in the SPA.

See `.env.example` for the full annotated configuration block.

## Why the in-memory store

The Chat Completions API is stateless — every request must include the full conversation context, and the server has no concept of threads. The provider keeps a client-side `CompletionsHistoryStore` so the UI's existing conversation/sidebar/history contract continues to work without a backend. `persist=false` (default) gives a stateless single-conversation UX; `persist=true` mirrors to `localStorage` for a multi-conversation experience with `VITE_CHAT_ENABLE_HISTORY=true`.

## Testing

### Build / static analysis
- `npx tsc --noEmit` — passes
- `npm run lint` — passes
- `npm run build` — passes; lazy chunk `completionsChatApi-*.js` weighs **6.47 kB raw / 2.42 kB gzipped**, only loaded when mode is `completions`

### Headless smoke test (mock OpenAI server, all `.ts` source loaded via tsx)
1. Non-streaming `sendMessage` — text echoed correctly — ✅
2. `fetchMessages` returns both user + assistant messages — ✅
3. Streaming `sendMessageStreaming` — chunks concat to onDone text, onStart fires with conversation id — ✅
4. Multi-turn history replay — second turn arrives with first turn's context in the payload — ✅
5. Conversation isolation — distinct ids for distinct conversations — ✅
6. Rename + delete CRUD — ✅
7. Mid-stream abort returns cleanly — ✅

### End-to-end against real model (`openai/gpt-4o-mini` via GitHub Models)
1. Non-streaming Q&A (`"What is 2+2?"` → `"4"`) — ✅
2. **Multi-turn memory**: turn 1 = `"Remember this exact word: TURQUOISE. Reply with only OK."`, turn 2 = `"Reply with only the exact word I asked you to remember."` → model replied `"TURQUOISE."` — ✅ (proves the history store + per-request message replay correctly threads context to the stateless endpoint)
3. Streaming delta-by-delta (9 real chunks) — ✅
4. `fetchMessages` after 2-turn conversation returns all 4 messages — ✅

## Relationship to #33

Both PRs add Chat Completions support, taking different architectural approaches:

| | #33 (BYOM) | This PR (completions) |
|---|---|---|
| Origin | Server-side proxy + translator | Client-side direct adapter |
| Files | 9 (+719 / −32) | 5 (+677 / −13) |
| Touches server? | Yes (4 new files, 5 modified) | **No** |
| Express required? | Yes | **No** |
| Translation layer? | OpenAI → Foundry Responses events | None (UI already handles OpenAI chunks) |
| Sample fit (Foundry Local on Azure Local) | OK — needs extra Express tier | **Native** — model endpoint already reachable |
| Production hardening | Server can inject auth, mTLS | Browser ships key; recommended pattern is reverse-proxy |

The two are not mutually exclusive — BYOM is the right choice when there's an operational requirement for server-side auth/audit, and `completions` is the right choice for the on-prem / edge scenarios this sample is most commonly used for.

For the Foundry Local on Azure Local code sample this PR was built for, the completions mode is the cleaner integration (no Express tier to deploy, model endpoint already on-cluster). I'd suggest landing this PR and closing #33 with a pointer here, unless reviewers want both options shipped.

Happy to mark this draft → ready for review pending discussion.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

